### PR TITLE
fix: use `produce()` to workaround solid-js/store bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This repo attempts to follow [semantic versioning](https://semver.org/).
 
 - none
 
+## 0.4.6 FIX (2022/8/19)
+
+### Fix
+
+- Workaround for a seemingly upstream issue with `solid-js/store` that would prevent subscribers from being informed when nested data changed. The fix was to use `produce()` instead of the standard `setState` function that a store returns.
+
 ## 0.4.5 FIX (2022/7/16)
 
 ### Fix

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "projects/*"
   ],
-  "version": "0.4.5",
+  "version": "0.4.6",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "concurrency": 2

--- a/projects/solid-forms-react/package.json
+++ b/projects/solid-forms-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-forms-react",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "sideEffects": false,
   "workspaces": {
     "nohoist": [
@@ -11,7 +11,7 @@
     "react": "^17.0.0"
   },
   "dependencies": {
-    "solid-forms": "^0.4.5",
+    "solid-forms": "^0.4.6",
     "solid-js": "^1.4.0"
   },
   "devDependencies": {

--- a/projects/solid-forms/package.json
+++ b/projects/solid-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-forms",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "A Solidjs library for working with forms.",
   "license": "Unlicense",
   "sideEffects": false,

--- a/projects/solid-forms/src/abstract-control-base.ts
+++ b/projects/solid-forms/src/abstract-control-base.ts
@@ -5,7 +5,7 @@ import type {
   AbstractControlInterface,
 } from './abstract-control';
 import { IAbstractControl } from './abstract-control';
-import { SetStoreFunction, Store } from 'solid-js/store';
+import { produce, SetStoreFunction, Store } from 'solid-js/store';
 import {
   Accessor,
   createComputed,
@@ -224,7 +224,16 @@ export function createAbstractControlBase<
 
       if (isEqual(this.self.pendingStore, newPendingStore)) return;
 
-      setControl('self', 'pendingStore', newPendingStore);
+      // We're using `produce()` here because using the standard solid Store
+      // nested setter has some bugs (i.e.
+      // `setControl('self', 'pendingStore', newPendingStore)`). I think the
+      // bugs are isolated to object values, so, at the moment, I'm only using
+      // produce where the value is an object.
+      setControl(
+        produce((state) => {
+          (state.self.pendingStore as Set<ControlId>) = newPendingStore;
+        })
+      );
     },
 
     setErrors(input, options) {
@@ -245,7 +254,17 @@ export function createAbstractControlBase<
 
       if (isEqual(this.self.errorsStore, newErrorsStore)) return;
 
-      setControl('self', 'errorsStore', newErrorsStore);
+      // We're using `produce()` here because using the standard solid Store
+      // nested setter has some bugs (i.e.
+      // `setControl('self', 'pendingStore', newPendingStore)`). I think the
+      // bugs are isolated to object values, so, at the moment, I'm only using
+      // produce where the value is an object.
+      setControl(
+        produce((state) => {
+          (state.self.errorsStore as Map<ControlId, ValidationErrors>) =
+            newErrorsStore;
+        })
+      );
     },
 
     patchErrors(input, options) {
@@ -255,10 +274,16 @@ export function createAbstractControlBase<
       >;
 
       if (input instanceof Map) {
+        // We're using `produce()` here because using the standard solid Store
+        // nested setter has some bugs (i.e.
+        // `setControl('self', 'pendingStore', newPendingStore)`). I think the
+        // bugs are isolated to object values, so, at the moment, I'm only using
+        // produce where the value is an object.
         setControl(
-          'self',
-          'errorsStore',
-          new Map([...existingStore, ...input])
+          produce((state) => {
+            (state.self.errorsStore as Map<ControlId, ValidationErrors>) =
+              new Map([...existingStore, ...input]);
+          })
         );
       } else {
         if (Object.keys(input).length === 0) return;
@@ -301,7 +326,17 @@ export function createAbstractControlBase<
 
         if (isEqual(this.self.errorsStore, newErrorsStore)) return;
 
-        setControl('self', 'errorsStore', newErrorsStore);
+        // We're using `produce()` here because using the standard solid Store
+        // nested setter has some bugs (i.e.
+        // `setControl('self', 'pendingStore', newPendingStore)`). I think the
+        // bugs are isolated to object values, so, at the moment, I'm only using
+        // produce where the value is an object.
+        setControl(
+          produce((state) => {
+            (state.self.errorsStore as Map<ControlId, ValidationErrors>) =
+              newErrorsStore;
+          })
+        );
       }
     },
 
@@ -330,13 +365,31 @@ export function createAbstractControlBase<
 
       if (isEqual(this.self.validatorStore, newValidatorsStore)) return;
 
-      setControl('self', 'validatorStore', newValidatorsStore);
+      // We're using `produce()` here because using the standard solid Store
+      // nested setter has some bugs (i.e.
+      // `setControl('self', 'pendingStore', newPendingStore)`). I think the
+      // bugs are isolated to object values, so, at the moment, I'm only using
+      // produce where the value is an object.
+      setControl(
+        produce((state) => {
+          (state.self.validatorStore as Map<ControlId, ValidatorFn<any>>) =
+            newValidatorsStore;
+        })
+      );
     },
 
     setData(key, input) {
       if (isEqual(this.data[key], input)) return;
-      // tslint:disable-next-line: no-any
-      setControl('data', key as any, input);
+      // We're using `produce()` here because using the standard solid Store
+      // nested setter has some bugs (i.e.
+      // `setControl('self', 'pendingStore', newPendingStore)`). I think the
+      // bugs are isolated to object values, so, at the moment, I'm only using
+      // produce where the value is an object.
+      setControl(
+        produce((state) => {
+          state.data[key] = input;
+        })
+      );
     },
   };
 
@@ -404,7 +457,17 @@ export function createAbstractControlBase<
 
           if (isEqual(control.self.errorsStore, newErrorsStore)) return;
 
-          setControl('self', 'errorsStore', newErrorsStore);
+          // We're using `produce()` here because using the standard solid Store
+          // nested setter has some bugs (i.e.
+          // `setControl('self', 'pendingStore', newPendingStore)`). I think the
+          // bugs are isolated to object values, so, at the moment, I'm only using
+          // produce where the value is an object.
+          setControl(
+            produce((state) => {
+              (state.self.errorsStore as Map<ControlId, ValidationErrors>) =
+                newErrorsStore;
+            })
+          );
         }
       )
     );

--- a/projects/solid-forms/src/abstract-control-container-base.ts
+++ b/projects/solid-forms/src/abstract-control-container-base.ts
@@ -23,7 +23,7 @@ import {
   IAbstractControlBaseOptions,
 } from './abstract-control-base';
 
-import { SetStoreFunction, Store } from 'solid-js/store';
+import { produce, SetStoreFunction, Store } from 'solid-js/store';
 import { Accessor, batch, createMemo } from 'solid-js';
 import { isEqual, mergeObj } from './util';
 import type { PartialDeep } from 'type-fest';
@@ -304,7 +304,17 @@ export function createAbstractControlContainerBase<
 
     setControls(controls: Controls) {
       if (isEqual(control.controls, controls)) return;
-      setControl('controls', controls);
+
+      // We're using `produce()` here because using the standard solid Store
+      // nested setter has some bugs (i.e.
+      // `setControl('self', 'pendingStore', newPendingStore)`). I think the
+      // bugs are isolated to object values, so, at the moment, I'm only using
+      // produce where the value is an object.
+      setControl(
+        produce((state) => {
+          (state.controls as Controls) = controls;
+        })
+      );
     },
 
     /**

--- a/projects/solid-forms/src/form-control.ts
+++ b/projects/solid-forms/src/form-control.ts
@@ -1,5 +1,4 @@
-import { batch } from 'solid-js';
-import { createStore, SetStoreFunction, Store } from 'solid-js/store';
+import { createStore, produce, SetStoreFunction, Store } from 'solid-js/store';
 import {
   IAbstractControl,
   ControlId,
@@ -74,7 +73,17 @@ export function createFormControl<
 
     setValue(value) {
       if (isEqual(this.value, value)) return;
-      setControl('rawValue', value);
+
+      // We're using `produce()` here because using the standard solid Store
+      // nested setter has some bugs (i.e.
+      // `setControl('self', 'pendingStore', newPendingStore)`). I think the
+      // bugs are isolated to object values, so, at the moment, I'm only using
+      // produce where the value could be an object.
+      setControl(
+        produce((state) => {
+          (state.rawValue as Value) = value;
+        })
+      );
     },
   } as IFormControl<Value, Data>);
 


### PR DESCRIPTION
I ran into some bugs seemingly caused by using the standard `solid-js/store` [`setState` function](https://www.solidjs.com/docs/latest/api#updating-stores) to set nested objects. The bug was that some changes wouldn't trigger subscribers to emit. Using `produce()` seems to eliminate those issues. 